### PR TITLE
Update command in readme

### DIFF
--- a/server-side-rendering/README.md
+++ b/server-side-rendering/README.md
@@ -37,7 +37,7 @@ npm run start:data
 #### starting the SSR server with bubbleprof
 
 ```
-clinic bubbleprof -- node src/server
+clinic bubbleprof -- node server
 ```
 Then run the autocannon script to request the stories.
 ```


### PR DESCRIPTION
For issue https://github.com/nearform/node-clinic-bubbleprof-examples/issues/5 (this repo) and  https://github.com/nearform/node-clinic-bubbleprof/issues/230 (Bubbleprof)

Currently if you follow the readme instructions to the letter, it fails because it is looking for `server-side-rendering/src/server`, which doesn't exist.

This instead points to `server-side-rendering/server`, which does exist.